### PR TITLE
fix(ddev): satisfy ansible-lint production profile

### DIFF
--- a/post-installation/tasks/shared/ddev.yaml
+++ b/post-installation/tasks/shared/ddev.yaml
@@ -55,13 +55,19 @@
             # Force mkcert to read/write keys in YOUR home dir, not /root/
             CAROOT: "/home/{{ username }}/.local/share/mkcert"
           become: true
+          register: mkcert_install
+          # Detect the work mkcert reports doing, rather than the absence of an
+          # "already installed" line - with several trust stores it prints both.
+          changed_when: >-
+            'is now installed' in (mkcert_install.stdout + mkcert_install.stderr)
+            or 'Created a new local CA' in (mkcert_install.stdout + mkcert_install.stderr)
 
         - name: Fix ownership of generated certificates
           ansible.builtin.file:
             path: "/home/{{ username }}/.local/share/mkcert"
             owner: "{{ username }}"
             group: "{{ username }}"
-            recurse: yes
+            recurse: true
           become: true
 
 # macOS installation


### PR DESCRIPTION
## Summary

Clears the two pre-existing `ansible-lint` failures in `tasks/shared/ddev.yaml` that block the production profile.

- `yaml[truthy]` — `recurse: yes` becomes `recurse: true`.
- `no-changed-when` — the `mkcert -install` command now reports its real state.

## On the mkcert change detection

`mkcert -install` is idempotent, so it needed a `changed_when`. Rather than testing for the absence of an "already installed" line, it detects the work mkcert reports doing:

```yaml
changed_when: >-
  'is now installed' in (...)
  or 'Created a new local CA' in (...)
```

The negative test would be wrong when several trust stores are involved — mkcert prints "already installed" for the system store and "is now installed" for Firefox in the same run, which is a genuine change.

Both strings were confirmed against the mkcert binary itself rather than assumed, and the logic is covered by assertions for the fresh, repeat and mixed-store cases.

## Verification

`ansible-lint post-installation/tasks/shared/ddev.yaml` passes the production profile.

Branched from `master`, independent of #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)