### PR TITLE
fix(git): drop task copying the deleted .git-templates-sample

### DIFF
--- a/post-installation/tasks/shared/git.yaml
+++ b/post-installation/tasks/shared/git.yaml
@@ -74,14 +74,6 @@
         - current_git_email.config_value != ""
         - current_git_email.config_value != None
 
-- name: Copy .git-templates-sample directory
-  ansible.builtin.copy:
-    src: "{{ role_path }}/defaults/.git-templates-sample"
-    dest: "~"
-    mode: "0755"
-  become_user: "{{ username }}"
-  become: true
-
 - name: Configure git user name
   when: git_user_name is defined
   community.general.git_config:


### PR DESCRIPTION
ce51b5d removed `post-installation/defaults/.git-templates-sample/` but left the task at `git.yaml:77` that copies it. Every run of the playbook aborts:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unexpected AnsibleActionFail error:
Could not find or access .../post-installation/defaults/.git-templates-sample on the Ansible Controller."}
```

Nothing sets `init.templatedir` anywhere in the repo, so the directory had no remaining consumer — removing the orphaned task is the fix, not restoring the deleted files.

## Verification

`ansible-playbook playbook_macos.yaml --check --diff` aborts on master partway through the run; with this change it completes: **57 ok, 13 changed, 0 failed**. `ansible-lint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)