### PR TITLE
fix(macos): repair silent cask failures, replace Gatekeeper-rejected apps

### DIFF
--- a/playbook_macos.yaml
+++ b/playbook_macos.yaml
@@ -5,6 +5,13 @@
   gather_facts: true
   strategy: linear
 
+  # Homebrew refuses to overwrite an app it did not install ("It seems there is
+  # already an App at ..."), which silently skips every cask whose app was
+  # installed by hand. --adopt takes ownership instead; it is a no-op on the
+  # upgrade path, so re-runs stay idempotent.
+  environment:
+    HOMEBREW_CASK_OPTS: "--adopt"
+
   roles:
     - role: post-installation
       tags: post-installation

--- a/post-installation/defaults/.config/ghostty/config
+++ b/post-installation/defaults/.config/ghostty/config
@@ -1,0 +1,19 @@
+# Ghostty — replaces alacritty, wezterm and iterm2.
+# Theme and font mirror .config/alacritty/alacritty.yaml.
+
+# Ghostty ships this palette, so there is no need to restate the 16 One Dark
+# hex values the alacritty config spells out.
+theme = Atom One Dark
+
+font-family = Fira Code
+font-size = 16
+
+# Quick terminal: the iTerm-style dropdown, toggled from any app.
+# Requires Accessibility permission on first use (System Settings > Privacy).
+keybind = global:super+d=toggle_quick_terminal
+quick-terminal-position = top
+quick-terminal-animation-duration = 0.1
+
+# super+d is new_split:right by default; the global binding above shadows it,
+# so move the split to super+shift+d rather than losing it.
+keybind = super+shift+d=new_split:right

--- a/post-installation/defaults/.config/ghostty/config
+++ b/post-installation/defaults/.config/ghostty/config
@@ -17,3 +17,8 @@ quick-terminal-animation-duration = 0.1
 # super+d is new_split:right by default; the global binding above shadows it,
 # so move the split to super+shift+d rather than losing it.
 keybind = super+shift+d=new_split:right
+
+# Machine-specific settings belong in config.local, which survives a re-run —
+# this file is overwritten every time. Same arrangement as ~/.zshrc.local.
+# The leading `?` makes the include optional, so a missing file is not an error.
+config-file = ?config.local

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -206,9 +206,11 @@ tool_sets:
     - obs
     - onlyoffice
     - postman
-    - qbittorrent
     - sublime-text
     - ticktick
+    # replaces qbittorrent, whose macOS builds are self-signed and rejected by
+    # Gatekeeper (cask deprecated, disabled 2026-09-01)
+    - transmission
     - viber
     - visual-studio-code
     - vlc

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -173,6 +173,7 @@ tool_sets:
 
   # GUI development tools (macOS)
   gui_dev_macos:
+    - dbeaver-community
     - alacritty
     - claude-code
     - db-browser-for-sqlite
@@ -193,25 +194,13 @@ tool_sets:
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
   gui_dev_macos_optional:
-    - jetbrains-toolbox
     - tableplus
 
   # GUI applications (macOS)
   gui_apps_macos:
-    - dbeaver-community
-    - digikam
     - firefox
-    - gitkraken
-    - google-drive
-    - obs
     - onlyoffice
-    - postman
-    - sublime-text
-    - ticktick
-    # replaces qbittorrent, whose macOS builds are self-signed and rejected by
-    # Gatekeeper (cask deprecated, disabled 2026-09-01)
     - transmission
-    - viber
     - visual-studio-code
     - vlc
     - whatsapp
@@ -219,6 +208,13 @@ tool_sets:
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
   gui_apps_macos_optional:
     - adguard-vpn
+    - digikam
+    - gitkraken
+    - obs
+    - sublime-text
+    - postman
+    - ticktick
+    - google-drive
     - google-chrome
     - microsoft-teams
     - slack
@@ -230,18 +226,19 @@ tool_sets:
     - alt-tab
     - appcleaner
     - copyclip
-    - flameshot
     - modern-csv
     - monitorcontrol
     - mos
     - pearcleaner
     - rectangle
+    # replaces flameshot, whose builds are unsigned and rejected by Gatekeeper
+    # (cask deprecated, disabled 2026-09-01)
+    - shottr
     - stats
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
   utility_apps_macos_optional:
     - betterdisplay
-    - shottr
 
   # Nerd Fonts (cross-platform)
   nerd_fonts:

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -34,11 +34,12 @@ download_dir: "/tmp/ansible"
 docker_compose: "/usr/local/bin/docker-compose"
 
 # Flameshot: installed from the upstream DMG rather than Homebrew, whose cask is
-# disabled 2026-09-01 for failing Gatekeeper. Bump both versions together — the
-# git tag carries the patch level, the DMG filename does not.
+# disabled 2026-09-01 for failing Gatekeeper. Upstream tags releases as x.y.z but
+# names the DMG x.y, so the filename drops the patch level rather than restating
+# the version — bumping flameshot_version alone is enough.
 flameshot_version: "14.0.0"
-flameshot_bundle_version: "14.0.0"
-flameshot_dmg: "Flameshot-14.0-macos-{{ 'arm64' if ansible_architecture == 'arm64' else 'intel' }}.dmg"
+flameshot_bundle_version: "{{ flameshot_version }}"
+flameshot_dmg: "Flameshot-{{ flameshot_version.split('.')[:2] | join('.') }}-macos-{{ 'arm64' if ansible_architecture == 'arm64' else 'intel' }}.dmg"
 flameshot_dmg_url: "https://github.com/flameshot-org/flameshot/releases/download/v{{ flameshot_version }}/{{ flameshot_dmg }}"
 flameshot_mount: "/Volumes/Flameshot"
 
@@ -231,7 +232,10 @@ tool_sets:
     - rectangle
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
-  utility_apps_macos_optional: []
+  utility_apps_macos_optional:
+    # flameshot is the day-to-day screenshot tool (see darwin/flameshot.yaml);
+    # shottr stays available for scrolling capture and OCR, which it lacks
+    - shottr
 
   # Nerd Fonts (cross-platform)
   nerd_fonts:

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -33,6 +33,15 @@ download_dir: "/tmp/ansible"
 # System files
 docker_compose: "/usr/local/bin/docker-compose"
 
+# Flameshot: installed from the upstream DMG rather than Homebrew, whose cask is
+# disabled 2026-09-01 for failing Gatekeeper. Bump both versions together — the
+# git tag carries the patch level, the DMG filename does not.
+flameshot_version: "14.0.0"
+flameshot_bundle_version: "14.0.0"
+flameshot_dmg: "Flameshot-14.0-macos-{{ 'arm64' if ansible_architecture == 'arm64' else 'intel' }}.dmg"
+flameshot_dmg_url: "https://github.com/flameshot-org/flameshot/releases/download/v{{ flameshot_version }}/{{ flameshot_dmg }}"
+flameshot_mount: "/Volumes/Flameshot"
+
 # Claude Code settings keys the playbook deletes outright. A key merely absent
 # from the template survives the merge, so removals have to be explicit.
 claude_purged_settings_keys:

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -174,11 +174,10 @@ tool_sets:
   # GUI development tools (macOS)
   gui_dev_macos:
     - dbeaver-community
-    - alacritty
     - claude-code
-    - db-browser-for-sqlite
-    - iterm2
-    - wezterm
+    # replaces alacritty + wezterm + iterm2: GPU-accelerated like alacritty,
+    # native, and has a built-in quick terminal (the iTerm dropdown)
+    - ghostty
     - zed
 
   # CocoaPods is required for Flutter/React Native iOS builds
@@ -193,8 +192,7 @@ tool_sets:
     - flutter
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
-  gui_dev_macos_optional:
-    - tableplus
+  gui_dev_macos_optional: []
 
   # GUI applications (macOS)
   gui_apps_macos:
@@ -207,17 +205,9 @@ tool_sets:
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
   gui_apps_macos_optional:
-    - adguard-vpn
     - digikam
     - gitkraken
-    - obs
     - sublime-text
-    - postman
-    - ticktick
-    - google-drive
-    - google-chrome
-    - microsoft-teams
-    - slack
     - zoom
 
   # Utility applications (macOS)
@@ -225,20 +215,14 @@ tool_sets:
     - alfred
     - alt-tab
     - appcleaner
-    - copyclip
-    - modern-csv
-    - monitorcontrol
+    # replaces copyclip, which is paid after its trial
+    - maccy
     - mos
     - pearcleaner
     - rectangle
-    # replaces flameshot, whose builds are unsigned and rejected by Gatekeeper
-    # (cask deprecated, disabled 2026-09-01)
-    - shottr
-    - stats
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
-  utility_apps_macos_optional:
-    - betterdisplay
+  utility_apps_macos_optional: []
 
   # Nerd Fonts (cross-platform)
   nerd_fonts:

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -13,6 +13,10 @@ mobile: false
 # Wipe ~/.vim/plugged before installing plugins. Off: a re-run must not destroy
 # a working plugin set. Turn on for a clean reinstall.
 nvim_reset: false
+# Prune developer tool caches (brew, npm, go, docker, ...). Off, and excluded
+# from `all`: provisioning must not delete data as a side effect. Opt in with
+# `-e prune_caches=true` or `--tags prune`.
+prune_caches: false
 kde: true
 all: false
 remove_snap: true
@@ -228,6 +232,7 @@ tool_sets:
     - modern-csv
     - monitorcontrol
     - mos
+    - pearcleaner
     - rectangle
     - stats
 

--- a/post-installation/files/prune_caches.sh
+++ b/post-installation/files/prune_caches.sh
@@ -54,12 +54,12 @@ have php && have composer && run "Composer" composer clear-cache --dry-run ::: c
 # container) and not `--volumes` (would delete database data). Dangling layers
 # and stopped containers only. Run those flags by hand if you mean them.
 have docker && run "Docker"        docker system df ::: docker system prune -f
-have gradle && run "Gradle daemon" ::: gradle --stop
 
-# Playwright/Puppeteer keep every browser build they ever downloaded; their CLIs
-# expose no prune, so this only reports. Delete old versions by hand.
-printf '\n=== browser automation caches (manual) ===\n'
-du -sh ~/Library/Caches/ms-playwright ~/.cache/puppeteer 2>/dev/null || true
+# These have no prune command that frees disk, so the script only reports their
+# size. Gradle in particular: `gradle --stop` shuts the daemon down and reclaims
+# nothing, so it is deliberately not run here. Delete by hand if you mean it.
+printf '\n=== no prune command available (manual) ===\n'
+du -sh ~/.gradle ~/Library/Caches/ms-playwright ~/.cache/puppeteer 2>/dev/null || true
 
 if ((DRY_RUN == 0)); then
   after=$(df -k / | awk 'NR==2 {print $4}')

--- a/post-installation/files/prune_caches.sh
+++ b/post-installation/files/prune_caches.sh
@@ -45,9 +45,11 @@ have pnpm   && run "pnpm"          ::: pnpm store prune
 have npm    && run "npm"           ::: npm cache clean --force
 have yarn   && run "yarn"          ::: yarn cache clean
 have go     && run "Go modules"    ::: go clean -modcache
-have cargo  && run "Cargo"         ::: cargo cache --autoclean
+# `cargo cache` is a separate crate, not built in — skip unless it's installed
+cargo cache --version >/dev/null 2>&1 && run "Cargo" ::: cargo cache --autoclean
 have pip3   && run "pip"           ::: pip3 cache purge
-have composer && run "Composer"    composer clear-cache --dry-run ::: composer clear-cache
+# the composer shim exists even without php, and errors out if php is missing
+have php && have composer && run "Composer" composer clear-cache --dry-run ::: composer clear-cache
 # Deliberately not `-a` (would delete every image not attached to a running
 # container) and not `--volumes` (would delete database data). Dangling layers
 # and stopped containers only. Run those flags by hand if you mean them.

--- a/post-installation/files/prune_caches.sh
+++ b/post-installation/files/prune_caches.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Reclaim disk space from developer tool caches.
+#
+# Every entry below delegates to the cache's OWN prune command. Nothing here
+# rm -rf's a guessed path: the tool that wrote the cache is the only thing that
+# reliably knows which parts are still referenced. Adding a `rm -rf ~/.some/cache`
+# line to this file is how it becomes dangerous — don't.
+#
+# Dry run by default. Pass --yes to actually delete.
+set -uo pipefail
+
+DRY_RUN=1
+[[ "${1:-}" == "--yes" ]] && DRY_RUN=0
+
+if ((DRY_RUN)); then
+  echo "DRY RUN — showing what would be pruned. Re-run with --yes to delete."
+  echo
+fi
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+before=$(df -k / | awk 'NR==2 {print $4}')
+
+# run <label> <dry-run cmd...> ::: <real cmd...>
+run() {
+  local label=$1; shift
+  local -a dry=() real=()
+  local seen=0
+  for arg in "$@"; do
+    if [[ $arg == ":::" ]]; then seen=1; continue; fi
+    if ((seen)); then real+=("$arg"); else dry+=("$arg"); fi
+  done
+
+  printf '\n=== %s ===\n' "$label"
+  if ((DRY_RUN)); then
+    if ((${#dry[@]})); then "${dry[@]}" 2>&1 | tail -5; else echo "(no dry-run mode; would run: ${real[*]})"; fi
+  else
+    "${real[@]}" 2>&1 | tail -5
+  fi
+}
+
+have brew   && run "Homebrew"      brew cleanup --prune=all --dry-run ::: brew cleanup --prune=all
+have uv     && run "uv"            ::: uv cache prune
+have pnpm   && run "pnpm"          ::: pnpm store prune
+have npm    && run "npm"           ::: npm cache clean --force
+have yarn   && run "yarn"          ::: yarn cache clean
+have go     && run "Go modules"    ::: go clean -modcache
+have cargo  && run "Cargo"         ::: cargo cache --autoclean
+have pip3   && run "pip"           ::: pip3 cache purge
+have composer && run "Composer"    composer clear-cache --dry-run ::: composer clear-cache
+# Deliberately not `-a` (would delete every image not attached to a running
+# container) and not `--volumes` (would delete database data). Dangling layers
+# and stopped containers only. Run those flags by hand if you mean them.
+have docker && run "Docker"        docker system df ::: docker system prune -f
+have gradle && run "Gradle daemon" ::: gradle --stop
+
+# Playwright/Puppeteer keep every browser build they ever downloaded; their CLIs
+# expose no prune, so this only reports. Delete old versions by hand.
+printf '\n=== browser automation caches (manual) ===\n'
+du -sh ~/Library/Caches/ms-playwright ~/.cache/puppeteer 2>/dev/null || true
+
+if ((DRY_RUN == 0)); then
+  after=$(df -k / | awk 'NR==2 {print $4}')
+  printf '\nReclaimed: %s\n' "$(( (after - before) / 1024 )) MB"
+fi
+
+cat <<'EOF'
+
+Not covered here: leftover config/support files from apps you have deleted.
+Use Pearcleaner (brew install --cask pearcleaner) or AppCleaner for those —
+they track which files belong to which bundle, which this script cannot.
+EOF

--- a/post-installation/tasks/darwin/dev_tools_gui.yaml
+++ b/post-installation/tasks/darwin/dev_tools_gui.yaml
@@ -14,7 +14,9 @@
       loop: "{{ tool_sets.gui_dev_macos + (tool_sets.gui_dev_macos_optional if all | bool else [])
          + (tool_sets.gui_mobile_macos if (mobile | bool) or (all | bool) else []) }}"
       register: dev_cask_results
-      failed_when: false
+      # ponytail: ignore_errors (not failed_when) so the summary below can still
+      # see failed=true; failed_when would rewrite it to false and hide failures
+      ignore_errors: true
 
   always:
     - name: Development tools installation summary

--- a/post-installation/tasks/darwin/flameshot.yaml
+++ b/post-installation/tasks/darwin/flameshot.yaml
@@ -31,6 +31,16 @@
         cmd: "hdiutil attach -nobrowse -readonly -mountpoint {{ flameshot_mount }} {{ download_dir }}/{{ flameshot_dmg }}"
       changed_when: true
 
+    # copy merges into an existing directory and never deletes extraneous files,
+    # so an upgrade would leave the previous version's frameworks inside the
+    # bundle. Remove first to guarantee the bundle is exactly what shipped.
+    - name: Remove any previous Flameshot bundle
+      ansible.builtin.file:
+        path: /Applications/Flameshot.app
+        state: absent
+      become_user: "{{ username }}"
+      become: true
+
     - name: Copy Flameshot into /Applications
       ansible.builtin.copy:
         src: "{{ flameshot_mount }}/Flameshot.app/"

--- a/post-installation/tasks/darwin/flameshot.yaml
+++ b/post-installation/tasks/darwin/flameshot.yaml
@@ -1,0 +1,65 @@
+---
+# Flameshot ships no notarized macOS build, so Homebrew deprecated the cask
+# (disabled 2026-09-01). Installing the upstream DMG keeps it working, at the
+# cost of an unsigned binary — hence the explicit checksum verification below
+# and the deliberate quarantine removal at the end.
+- name: Check installed Flameshot version
+  ansible.builtin.command:
+    cmd: >-
+      defaults read /Applications/Flameshot.app/Contents/Info.plist
+      CFBundleShortVersionString
+  register: flameshot_installed
+  changed_when: false
+  failed_when: false
+
+- name: Install Flameshot from upstream release
+  when: flameshot_installed.stdout | trim != flameshot_bundle_version
+  block:
+    - name: Download Flameshot DMG and verify against upstream checksum
+      ansible.builtin.get_url:
+        url: "{{ flameshot_dmg_url }}"
+        dest: "{{ download_dir }}/{{ flameshot_dmg }}"
+        # get_url fetches the .sha256sum file and compares — a failed match
+        # fails the task, so an altered download never reaches /Applications
+        checksum: "sha256:{{ flameshot_dmg_url }}.sha256sum"
+        mode: "0644"
+      become_user: "{{ username }}"
+      become: true
+
+    - name: Mount Flameshot DMG
+      ansible.builtin.command:
+        cmd: "hdiutil attach -nobrowse -readonly -mountpoint {{ flameshot_mount }} {{ download_dir }}/{{ flameshot_dmg }}"
+      changed_when: true
+
+    - name: Copy Flameshot into /Applications
+      ansible.builtin.copy:
+        src: "{{ flameshot_mount }}/Flameshot.app/"
+        dest: /Applications/Flameshot.app/
+        mode: preserve
+        remote_src: true
+      become_user: "{{ username }}"
+      become: true
+
+  always:
+    - name: Unmount Flameshot DMG
+      ansible.builtin.command:
+        cmd: "hdiutil detach {{ flameshot_mount }} -force"
+      changed_when: true
+      failed_when: false
+
+# Unsigned build: without this macOS refuses to launch it at all. This is a
+# deliberate trade — the checksum above is what stands in for a signature.
+- name: Check whether Flameshot is quarantined
+  ansible.builtin.command:
+    cmd: xattr -p com.apple.quarantine /Applications/Flameshot.app
+  register: flameshot_quarantine
+  changed_when: false
+  failed_when: false
+
+- name: Remove quarantine flag from Flameshot
+  ansible.builtin.command:
+    cmd: xattr -rd com.apple.quarantine /Applications/Flameshot.app
+  when: flameshot_quarantine.rc == 0
+  changed_when: true
+  become_user: "{{ username }}"
+  become: true

--- a/post-installation/tasks/darwin/general_use_software_gui.yaml
+++ b/post-installation/tasks/darwin/general_use_software_gui.yaml
@@ -13,7 +13,9 @@
         HOMEBREW_NO_AUTO_UPDATE: "1"
       loop: "{{ tool_sets.gui_apps_macos + (tool_sets.gui_apps_macos_optional if all | bool else []) }}"
       register: gui_cask_results
-      failed_when: false
+      # ponytail: ignore_errors (not failed_when) so the summaries can still see
+      # failed=true; failed_when rewrites it to false and hides every failure
+      ignore_errors: true
 
   always:
     - name: GUI applications installation summary
@@ -42,7 +44,7 @@
     HOMEBREW_NO_AUTO_UPDATE: "1"
   loop: "{{ tool_sets.utility_apps_macos + (tool_sets.utility_apps_macos_optional if all | bool else []) }}"
   register: utility_cask_results
-  failed_when: false
+  ignore_errors: true
 
 - name: Utility applications installation summary
   ansible.builtin.debug:
@@ -69,7 +71,7 @@
   loop_control:
     label: "{{ item.name }}"
   register: mas_results
-  failed_when: false
+  ignore_errors: true
 
 - name: Mac App Store installation summary
   ansible.builtin.debug:

--- a/post-installation/tasks/darwin/ghostty.yaml
+++ b/post-installation/tasks/darwin/ghostty.yaml
@@ -1,0 +1,16 @@
+---
+- name: Create Ghostty config directory
+  ansible.builtin.file:
+    path: "{{ user_home }}/.config/ghostty"
+    state: directory
+    mode: "0755"
+  become_user: "{{ username }}"
+  become: true
+
+- name: Copy Ghostty config file
+  ansible.builtin.copy:
+    src: "{{ role_path }}/defaults/.config/ghostty/config"
+    dest: "{{ user_home }}/.config/ghostty/config"
+    mode: "0644"
+  become_user: "{{ username }}"
+  become: true

--- a/post-installation/tasks/darwin/ghostty.yaml
+++ b/post-installation/tasks/darwin/ghostty.yaml
@@ -3,7 +3,8 @@
   ansible.builtin.file:
     path: "{{ user_home }}/.config/ghostty"
     state: directory
-    mode: "0755"
+    # only the owner's Ghostty reads this; no reason to expose it to others
+    mode: "0700"
   become_user: "{{ username }}"
   become: true
 
@@ -11,6 +12,6 @@
   ansible.builtin.copy:
     src: "{{ role_path }}/defaults/.config/ghostty/config"
     dest: "{{ user_home }}/.config/ghostty/config"
-    mode: "0644"
+    mode: "0600"
   become_user: "{{ username }}"
   become: true

--- a/post-installation/tasks/darwin/gui_applications.yaml
+++ b/post-installation/tasks/darwin/gui_applications.yaml
@@ -13,6 +13,9 @@
     apply:
       tags: [dev-tools, gui, ghostty]
   when: (dev_tools_gui | bool) or (all | bool)
+  # the parent include applies `gui` to everything here; without its own tag the
+  # include itself is unreachable via --tags ghostty
+  tags: [dev-tools, gui, ghostty]
 
 - name: Install general GUI software
   ansible.builtin.include_tasks:

--- a/post-installation/tasks/darwin/gui_applications.yaml
+++ b/post-installation/tasks/darwin/gui_applications.yaml
@@ -7,6 +7,13 @@
       tags: [dev-tools, gui]
   when: (dev_tools_gui | bool) or (all | bool)
 
+- name: Configure Ghostty
+  ansible.builtin.include_tasks:
+    file: darwin/ghostty.yaml
+    apply:
+      tags: [dev-tools, gui, ghostty]
+  when: (dev_tools_gui | bool) or (all | bool)
+
 - name: Install general GUI software
   ansible.builtin.include_tasks:
     file: darwin/general_use_software_gui.yaml

--- a/post-installation/tasks/darwin/gui_applications.yaml
+++ b/post-installation/tasks/darwin/gui_applications.yaml
@@ -20,3 +20,13 @@
     apply:
       tags: [gui]
   when: (gui | bool) or (all | bool)
+
+- name: Install Flameshot
+  ansible.builtin.include_tasks:
+    file: darwin/flameshot.yaml
+    apply:
+      tags: [gui, flameshot]
+  when: (gui | bool) or (all | bool)
+  # the parent include applies `gui` to everything here; without its own tag the
+  # include itself is unreachable via --tags flameshot
+  tags: [gui, flameshot]

--- a/post-installation/tasks/main.yaml
+++ b/post-installation/tasks/main.yaml
@@ -87,6 +87,14 @@
     - "'KDE' in (ansible_env.XDG_CURRENT_DESKTOP | default('') | upper)"
   tags: [always]
 
+- name: Prune developer tool caches
+  ansible.builtin.include_tasks:
+    file: shared/prune_caches.yaml
+    apply:
+      tags: [prune]
+  when: prune_caches | bool
+  tags: [always]
+
 - name: Cleanup and finalization
   ansible.builtin.include_tasks:
     file: shared/finalization.yaml

--- a/post-installation/tasks/main.yaml
+++ b/post-installation/tasks/main.yaml
@@ -23,6 +23,7 @@
     vpn: "{{ true if 'vpn' in ansible_run_tags else vpn }}"
     fonts: "{{ true if 'fonts' in ansible_run_tags else fonts }}"
     mobile: "{{ true if 'mobile' in ansible_run_tags else mobile }}"
+    prune_caches: "{{ true if 'prune' in ansible_run_tags else prune_caches }}"
   when: ansible_run_tags | difference(['all', 'always']) | length > 0
   tags: [always]
 

--- a/post-installation/tasks/shared/prune_caches.yaml
+++ b/post-installation/tasks/shared/prune_caches.yaml
@@ -7,7 +7,8 @@
   become: true
   become_user: "{{ username }}"
   register: prune_result
-  changed_when: true
+  # the script prints its own total; a run that freed nothing is not a change
+  changed_when: "'Reclaimed: 0 MB' not in prune_result.stdout"
 
 - name: Cache prune output
   ansible.builtin.debug:

--- a/post-installation/tasks/shared/prune_caches.yaml
+++ b/post-installation/tasks/shared/prune_caches.yaml
@@ -1,0 +1,14 @@
+---
+# Deliberately NOT part of `all=true`: provisioning a machine and deleting
+# caches on it are different jobs, and a re-run should never quietly free disk.
+- name: Prune developer tool caches
+  ansible.builtin.script:
+    cmd: "{{ role_path }}/files/prune_caches.sh --yes"
+  become: true
+  become_user: "{{ username }}"
+  register: prune_result
+  changed_when: true
+
+- name: Cache prune output
+  ansible.builtin.debug:
+    var: prune_result.stdout_lines


### PR DESCRIPTION
## Why

A run with `-e all=true` reported Zoom as installed when it was not, and several
macOS apps were silently never installed at all. Root cause: Homebrew refuses to
overwrite an app it did not install —

```
Error: It seems there is already an App at '/Applications/Firefox.app'.
```

— and `failed_when: false` on the cask loops rewrote `failed` to `false` on every
result, so the summary's `rejectattr('failed')` bucket reported those failures as
"Already up-to-date". The "Failed/Skipped" line was structurally always empty.

## Changes

**Cask install correctness**
- `failed_when: false` → `ignore_errors: true` on the four cask/mas loops, so the
  summaries can still see `failed=true`. `ignore_errors` is permitted by the
  production lint profile when the task also registers.
- `HOMEBREW_CASK_OPTS: "--adopt"` at play level in `playbook_macos.yaml`, so casks
  adopt pre-existing apps instead of aborting. Verified `--adopt` is accepted and
  a no-op on the upgrade path, so re-runs stay idempotent. Play- and task-level
  `environment` merge, so the tasks' own `HOMEBREW_NO_AUTO_UPDATE` is preserved.

**Gatekeeper-failing casks replaced**
- qbittorrent → transmission. qBittorrent's macOS builds are self-signed
  (`TeamIdentifier=not set`, `spctl: rejected`); the cask is deprecated and
  disabled 2026-09-01. Transmission is notarized Developer ID.
- flameshot → installed from the upstream DMG instead (below), since no notarized
  open-source equivalent exists on macOS.

**Flameshot from upstream release** (`darwin/flameshot.yaml`)
- `get_url` with `checksum: "sha256:<url>.sha256sum"` — Ansible fetches the
  publisher's checksum file and fails the task on mismatch, so an altered download
  never reaches `/Applications`.
- Version-gated: skips entirely when the installed bundle already matches.
- `block`/`always` so the DMG is unmounted even on failure.
- Quarantine removal is conditional on the flag actually being present, so re-runs
  report no change. This is a deliberate trade-off: the binary is unsigned, and the
  checksum stands in for a signature.

**Terminal consolidation**
- ghostty replaces alacritty + wezterm + iterm2: GPU-accelerated, native, and has
  a built-in quick terminal (the iTerm dropdown).
- `defaults/.config/ghostty/config` mirrors the existing `alacritty.yaml` theme and
  font, using Ghostty's built-in `Atom One Dark` rather than restating 16 hex values.
- `super+d` is `new_split:right` by default and the global quick-terminal binding
  shadows it, so the split moves to `super+shift+d`.

**Cache pruning** (`prune_caches` flag, off by default, excluded from `all`)
- `files/prune_caches.sh` delegates to each cache's own prune command
  (`brew cleanup`, `uv cache prune`, `go clean -modcache`, …) rather than `rm -rf`ing
  guessed paths. Dry run by default.
- Docker uses plain `system prune -f` — deliberately not `-a` and not `--volumes`.

**App list cleanup**
- Dropped apps idle 195–567 days or never launched; copyclip → maccy (its trial
  expires); added pearcleaner.

## Verification

- `ansible-lint` production profile: 16 failures before and after — all pre-existing
  in Debian task files, none introduced.
- `shellcheck` clean on `prune_caches.sh`.
- `ghostty +validate-config` clean on the new config.
- Flameshot task exercised end-to-end on a real machine: install path
  (`changed=4`), re-run idempotent (`changed=0`), app launches, Qt framework
  symlinks preserved (36 = 36) and size identical to a manual install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
