### PR TITLE
fix: point every URL at the renamed griffin repo

### DIFF
--- a/.github/workflows/wsl.yaml
+++ b/.github/workflows/wsl.yaml
@@ -45,26 +45,26 @@ jobs:
       - shell: wsl-bash {0}
         run: |
           WORKSPACE_PATH=$(wslpath "${{ github.workspace }}")
-          cp -r "$WORKSPACE_PATH" /home/test/ansible-post-installation
+          cp -r "$WORKSPACE_PATH" /home/test/griffin
 
       - shell: wsl-bash {0}
-        run: cd /home/test/ansible-post-installation && echo "testpw" > .github/workflows/ansible_become_password.txt
+        run: cd /home/test/griffin && echo "testpw" > .github/workflows/ansible_become_password.txt
 
       - shell: wsl-bash {0}
-        run: chmod 600 /home/test/ansible-post-installation/.github/workflows/ansible_become_password.txt
+        run: chmod 600 /home/test/griffin/.github/workflows/ansible_become_password.txt
 
       - shell: wsl-bash {0}
-        run: ls -la /home/test/ansible-post-installation/.github/workflows
+        run: ls -la /home/test/griffin/.github/workflows
 
       - name: Install Ansible collections
         shell: wsl-bash {0}
         run: |
-          cd /home/test/ansible-post-installation/ && ansible-galaxy collection install -r requirements.yaml
+          cd /home/test/griffin/ && ansible-galaxy collection install -r requirements.yaml
 
       - name: Run ansible playbook
         shell: wsl-bash {0}
         run: |
-          cd /home/test/ansible-post-installation/
+          cd /home/test/griffin/
           ansible-playbook ./playbook.yaml \
             --become-password-file .github/workflows/ansible_become_password.txt \
             -e all=true \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome contributions from the community to make Griffin even better! Whether
 
 There are several ways you can contribute to Griffin:
 
-*   **Report Bugs:** If you encounter any bugs or unexpected behavior, please open an issue on the [GitHub repository](https://github.com/TerrorSquad/ansible-post-installation). Provide detailed information about the issue, including steps to reproduce it.
+*   **Report Bugs:** If you encounter any bugs or unexpected behavior, please open an issue on the [GitHub repository](https://github.com/TerrorSquad/griffin). Provide detailed information about the issue, including steps to reproduce it.
 *   **Suggest Enhancements:** Have an idea for a new feature or improvement? Feel free to open an issue to discuss it.
 *   **Improve Documentation:** Help us make the documentation clearer and more comprehensive. You can suggest edits, fix typos, or add new sections.
 *   **Submit Code:** If you're comfortable with Ansible and want to contribute code, you can fork the repository, make your changes, and submit a pull request.
@@ -39,7 +39,7 @@ Please note that this project adheres to a [Code of Conduct](code-of-conduct). B
 
 ## Getting Help
 
-If you have any questions or need assistance, feel free to create an issue in the [GitHub repository](https://github.com/TerrorSquad/ansible-post-installation).
+If you have any questions or need assistance, feel free to create an issue in the [GitHub repository](https://github.com/TerrorSquad/griffin).
 
 ## Thank You!
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Griffin: Effortless Cross-Platform Configuration
 
-[![Ubuntu](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/ubuntu.yaml/badge.svg)](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/ubuntu.yaml)
-[![WSL](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/wsl.yaml/badge.svg)](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/wsl.yaml)
-[![macOS](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/macos.yaml/badge.svg)](https://github.com/TerrorSquad/ansible-post-installation/actions/workflows/macos.yaml)
+[![Ubuntu](https://github.com/TerrorSquad/griffin/actions/workflows/ubuntu.yaml/badge.svg)](https://github.com/TerrorSquad/griffin/actions/workflows/ubuntu.yaml)
+[![WSL](https://github.com/TerrorSquad/griffin/actions/workflows/wsl.yaml/badge.svg)](https://github.com/TerrorSquad/griffin/actions/workflows/wsl.yaml)
+[![macOS](https://github.com/TerrorSquad/griffin/actions/workflows/macos.yaml/badge.svg)](https://github.com/TerrorSquad/griffin/actions/workflows/macos.yaml)
 
 ## Overview
 
@@ -32,7 +32,7 @@ Griffin is an Ansible playbook designed to automate the installation and configu
 
 For detailed installation instructions, usage guides, and FAQs, please refer to our comprehensive documentation:
 
-[**https://terrorsquad.github.io/ansible-post-installation/**](https://terrorsquad.github.io/ansible-post-installation/)
+[**https://terrorsquad.github.io/griffin/**](https://terrorsquad.github.io/griffin/)
 
 ## License
 

--- a/add_zscaler_root_cert.sh
+++ b/add_zscaler_root_cert.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Fetch the Zscaler root certificate
-URL="https://raw.githubusercontent.com/TerrorSquad/ansible-post-installation/master/post-installation/defaults/ZscalerRootCA.crt"
+URL="https://raw.githubusercontent.com/TerrorSquad/griffin/master/post-installation/defaults/ZscalerRootCA.crt"
 LOCATION_TO_STORE="/usr/local/share/ca-certificates/ZscalerRootCA.crt"
 
 # Download with error checking and output suppression

--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -16,10 +16,10 @@ export default defineAppConfig({
 
   github: {
     owner: "terrorsquad",
-    name: "ansible-post-installation",
+    name: "griffin",
     branch: "master",
     rootDir: "docs",
-    url: "https://github.com/terrorsquad/ansible-post-installation",
+    url: "https://github.com/terrorsquad/griffin",
   },
 
   socials: {

--- a/docs/content/1.getting_started/2.installation.md
+++ b/docs/content/1.getting_started/2.installation.md
@@ -38,7 +38,7 @@ navigation:
   If you are behind a corporate proxy (e.g., Zscaler), install the root certificate:
   
   ```bash
-  curl -k -s https://raw.githubusercontent.com/TerrorSquad/ansible-post-installation/master/add_zscaler_root_cert.sh | bash
+  curl -k -s https://raw.githubusercontent.com/TerrorSquad/griffin/master/add_zscaler_root_cert.sh | bash
   ```
 ::
 

--- a/docs/content/1.getting_started/3.usage.md
+++ b/docs/content/1.getting_started/3.usage.md
@@ -13,9 +13,9 @@ Follow these steps to transform your system.
   ### Download the Playbook
   Clone the repository or download the source code.
   ```bash [Terminal]
-  wget https://github.com/TerrorSquad/ansible-post-installation/archive/refs/heads/master.zip \
+  wget https://github.com/TerrorSquad/griffin/archive/refs/heads/master.zip \
   && unzip master.zip \
-  && cd ansible-post-installation-master
+  && cd griffin-master
   ```
 
   ### Run the Installation

--- a/docs/content/3.support/1.faq.md
+++ b/docs/content/3.support/1.faq.md
@@ -55,7 +55,7 @@ navigation:
   :::item{label="I'm encountering an error I can't resolve. Where can I get help?"}
   If you're facing an issue you can't troubleshoot, you can:
 
-  *   Create an issue on the project's [GitHub repository](https://github.com/TerrorSquad/ansible-post-installation).
+  *   Create an issue on the project's [GitHub repository](https://github.com/TerrorSquad/griffin).
   :::
 
   :::item{label="Does Griffin work on WSL (Windows Subsystem for Linux)?"}

--- a/docs/content/3.support/2.contributing.md
+++ b/docs/content/3.support/2.contributing.md
@@ -9,7 +9,7 @@ navigation:
 
 There are several ways you can contribute to Griffin:
 
-*   **Report Bugs:** If you encounter any bugs or unexpected behavior, please open an issue on the [GitHub repository](https://github.com/TerrorSquad/ansible-post-installation). Provide detailed information about the issue, including steps to reproduce it.
+*   **Report Bugs:** If you encounter any bugs or unexpected behavior, please open an issue on the [GitHub repository](https://github.com/TerrorSquad/griffin). Provide detailed information about the issue, including steps to reproduce it.
 *   **Suggest Enhancements:** Have an idea for a new feature or improvement? Feel free to open an issue to discuss it.
 *   **Improve Documentation:** Help us make the documentation clearer and more comprehensive. You can suggest edits, fix typos, or add new sections.
 *   **Submit Code:** If you're comfortable with Ansible and want to contribute code, you can fork the repository, make your changes, and submit a pull request.
@@ -29,7 +29,7 @@ Please note that this project adheres to a [Code of Conduct](/support/code_of_co
 
 ## Getting Help
 
-If you have any questions or need assistance, feel free to create an issue in the [GitHub repository](https://github.com/TerrorSquad/ansible-post-installation).
+If you have any questions or need assistance, feel free to create an issue in the [GitHub repository](https://github.com/TerrorSquad/griffin).
 
 ## Thank You!
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -15,7 +15,7 @@ main:
     ::UButton{to="/getting_started/introduction" icon="i-heroicons-rocket-launch" size="xl"}
       Get Started
     ::
-    ::UButton{to="https://github.com/TerrorSquad/ansible-post-installation/" target="_blank" color="gray" variant="ghost" icon="i-simple-icons-github" size="xl"}
+    ::UButton{to="https://github.com/TerrorSquad/griffin/" target="_blank" color="gray" variant="ghost" icon="i-simple-icons-github" size="xl"}
       Star on GitHub
     ::
   ::

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -5,12 +5,12 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
 
   app: {
-    baseURL: '/ansible-post-installation/',
+    baseURL: '/griffin/',
     buildAssetsDir: 'assets',
   },
 
   site: {
-    url: 'https://terrorsquad.github.io/ansible-post-installation',
+    url: 'https://terrorsquad.github.io/griffin',
     name: 'Griffin',
   },
 

--- a/post-installation/tasks/main.yaml
+++ b/post-installation/tasks/main.yaml
@@ -108,4 +108,4 @@
     msg:
       - "🎉 Griffin installation complete!"
       - "Please restart your machine to ensure all changes take effect."
-      - "Check the documentation at: https://terrorsquad.github.io/ansible-post-installation/"
+      - "Check the documentation at: https://terrorsquad.github.io/griffin/"


### PR DESCRIPTION
Follow-up to renaming `ansible-post-installation` → `griffin`.

GitHub redirects repo and git URLs, so most of this diff is cosmetic. Three parts are not:

- **`docs/nuxt.config.ts`** — `baseURL` was `/ansible-post-installation/`, which is the GitHub Pages path. The site is broken right now; this is the fix. Merging triggers `documentation.yaml` and restores it at https://terrorsquad.github.io/griffin/
- **`docs/content/1.getting_started/3.usage.md`** — the download block ended in `cd ansible-post-installation-master`. GitHub names the archive after the repo, so that directory is now `griffin-master` and the instructions fail on the last line.
- **`add_zscaler_root_cert.sh`** and **`post-installation/tasks/main.yaml`** — raw `githubusercontent` URLs. They redirect today, but that isn't guaranteed for raw content.

The rest is CI badges, contributing links and workflow scratch paths.

`CHANGELOG.md` is deliberately untouched — release-please owns it, and its links are historical records rather than instructions anyone follows.

⚠️ The old docs URL `terrorsquad.github.io/ansible-post-installation/` will 404 permanently. GitHub does not redirect Pages across renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBSgUSv3F2Ry6TFkiT4rHB