### PR TITLE
feat(gui): opt-in Viber, gate heavy GUI apps behind `all`, add flag picker

### DIFF
--- a/docs/content/1.getting_started/4.configuration.md
+++ b/docs/content/1.getting_started/4.configuration.md
@@ -61,7 +61,13 @@ If you'd rather not memorize flags, `./install.sh` reads them straight out of `d
 ./install.sh
 ```
 
-It shows the resulting `ansible-playbook` command and asks before running it. Default-on flags (`kde`, `remove_snap`) come pre-selected, so pressing Enter reproduces the standard install. Requires [`gum`](https://github.com/charmbracelet/gum).
+Type a number to toggle a flag (or several at once: `1 4 7`), `a` for everything, `n` for nothing, `q` to quit. Press Enter when done — it shows the resulting `ansible-playbook` command and asks before running it.
+
+Flags default to their values in `defaults/main.yaml`, so pressing Enter straight away reproduces the standard install.
+
+::callout{icon="i-heroicons-check-badge"}
+No dependencies — plain `bash`, nothing to install first. It runs on a fresh system before Homebrew exists.
+::
 
 ### Examples
 

--- a/docs/content/1.getting_started/4.configuration.md
+++ b/docs/content/1.getting_started/4.configuration.md
@@ -45,7 +45,23 @@ Griffin is modular. You can control exactly what gets installed using Ansible's 
 
   :badge[Default: false]{color="gray" variant="soft"} :badge[Type: boolean]{color="gray" variant="outline"}
   ::::
+
+  ::::card{title="viber" icon="i-heroicons-chat-bubble-left-right"}
+  Installs Viber (Linux only). Not included in `all`.
+
+  :badge[Default: false]{color="gray" variant="soft"} :badge[Type: boolean]{color="gray" variant="outline"}
+  ::::
 :::
+
+### Interactive picker
+
+If you'd rather not memorize flags, `./install.sh` reads them straight out of `defaults/main.yaml` and lets you tick what you want:
+
+```bash
+./install.sh
+```
+
+It shows the resulting `ansible-playbook` command and asks before running it. Default-on flags (`kde`, `remove_snap`) come pre-selected, so pressing Enter reproduces the standard install. Requires [`gum`](https://github.com/charmbracelet/gum).
 
 ### Examples
 

--- a/docs/content/2.features/1.whats_installed.md
+++ b/docs/content/2.features/1.whats_installed.md
@@ -92,7 +92,7 @@ This ensures you get the latest versions of modern CLI tools while maintaining s
   title: Communication & Office
   icon: i-heroicons-chat-bubble-left-right
   ---
-  **Slack**, **Zoom**, **Teams**, **Tixati**, **ONLYOFFICE**
+  **Slack**, **Teams**, **WhatsApp**, **ONLYOFFICE**
   ::::
 :::
 
@@ -122,14 +122,13 @@ This ensures you get the latest versions of modern CLI tools while maintaining s
   :::item{label="Internet & Networking" icon="i-heroicons-globe-alt"}
   - **Web Browser:** Google Chrome
   - **Networking Tools:** curl, curlie, gping, httpie, httpstat, openconnect, xh
-  - **Torrent Client:** Tixati
+  - **Torrent Client:** Tixati :badge[`all` only]{color="secondary"}
   :::
 
   :::item{label="Communication & Office" icon="i-heroicons-chat-bubble-left-right"}
-  - **Communication:** Slack, Viber, Zoom, Microsoft Teams :badge[macOS], WhatsApp :badge[macOS]
+  - **Communication:** Slack, Microsoft Teams :badge[macOS], WhatsApp :badge[macOS], Zoom :badge[`all` only]{color="secondary"}, Viber :badge[opt-in: `-e viber=true`]{color="secondary"}
   - **Office Suite:** ONLYOFFICE
-  - **Email Client:** Mailspring :badge[Linux]{color="secondary"}
-  - **Productivity:** TickTick :badge[macOS], RescueTime :badge[Linux]{color="secondary"}
+  - **Productivity:** TickTick :badge[macOS], RescueTime :badge[Linux, `all` only]{color="secondary"}
   :::
 
   :::item{label="Multimedia & Graphics" icon="i-heroicons-photo"}
@@ -140,7 +139,7 @@ This ensures you get the latest versions of modern CLI tools while maintaining s
 
   :::item{label="System Utilities & Customization" icon="i-heroicons-cog-6-tooth"}
   - **macOS Utilities:** AppCleaner, Maccy, Pearcleaner
-  - **Linux Utilities:** Bleachbit, Redshift, Variety, Papirus Theme, Adapta Themes, Unified Remote, input-remapper, libinput-gestures
+  - **Linux Utilities:** Bleachbit, Redshift, Variety, Papirus Theme, Adapta Themes, input-remapper, libinput-gestures, Unified Remote :badge[`all` only]{color="secondary"}
   - **Monitoring & File Mgmt:** btop, htop, procs, duf, dust, eza, fd, fzf, lsd, ncdu
   :::
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Interactive picker for Griffin's feature flags.
+#
+# The flag list is read from post-installation/defaults/main.yaml, so adding a
+# flag there is the only edit needed - this script picks it up automatically.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+DEFAULTS="post-installation/defaults/main.yaml"
+[ -f "$DEFAULTS" ] || { echo "Run this from the Griffin checkout." >&2; exit 1; }
+
+case "$(uname -s)" in
+  Darwin) PLAYBOOK="playbook_macos.yaml" ;;
+  *) PLAYBOOK="playbook.yaml" ;;
+esac
+
+# mapfile is bash 4+; macOS ships bash 3.2 and this script runs before
+# Homebrew provides a newer one. `while read` works on both.
+#
+# Boolean flags, in file order. Skips `all` - it is the "everything" shortcut,
+# not a per-feature choice.
+FLAGS=()
+while IFS= read -r flag; do
+  FLAGS+=("$flag")
+done < <(awk '/^[a-z_]+: (true|false)$/ {
+                split($0, f, ":")
+                if (f[1] != "all") print f[1]
+              }' "$DEFAULTS")
+
+[ ${#FLAGS[@]} -gt 0 ] || { echo "No flags found in $DEFAULTS." >&2; exit 1; }
+
+# Default-on flags get pre-selected so the picker reflects current behaviour.
+PRESELECTED=()
+while IFS= read -r flag; do
+  PRESELECTED+=("$flag")
+done < <(awk '/^[a-z_]+: true$/ {split($0, f, ":"); if (f[1] != "all") print f[1]}' "$DEFAULTS")
+
+if ! command -v gum >/dev/null 2>&1; then
+  echo "gum is not installed. Either install it (brew install gum) or run:"
+  echo "  ansible-playbook ./$PLAYBOOK -K -e all=true"
+  exit 1
+fi
+
+gum style --border rounded --padding "0 1" \
+  "Griffin" "Pick what to install. Space selects, Enter confirms."
+
+selected_csv=$(IFS=,; echo "${PRESELECTED[*]-}")
+CHOSEN=()
+while IFS= read -r choice; do
+  CHOSEN+=("$choice")
+done < <(gum choose --no-limit --height 20 \
+           --selected "$selected_csv" \
+           --header "Feature flags (Ctrl-C to abort):" \
+           "${FLAGS[@]}")
+
+# gum exits 0 with no output if the user selects nothing.
+if [ ${#CHOSEN[@]} -eq 0 ]; then
+  echo "Nothing selected - installing core CLI tools and shell environment only."
+fi
+
+# Every flag is passed explicitly, on or off. Passing only the chosen ones
+# would let a default-true flag (kde, remove_snap) survive being deselected.
+ARGS=()
+for flag in "${FLAGS[@]}"; do
+  value=false
+  for chosen in ${CHOSEN[@]+"${CHOSEN[@]}"}; do
+    [ "$chosen" = "$flag" ] && value=true && break
+  done
+  ARGS+=(-e "$flag=$value")
+done
+
+echo
+echo "ansible-playbook ./$PLAYBOOK -K ${ARGS[*]}"
+echo
+gum confirm "Run it?" || exit 0
+
+exec ansible-playbook "./$PLAYBOOK" -K "${ARGS[@]}"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Interactive picker for Griffin's feature flags.
 #
+# Deliberately dependency-free: this runs on a fresh system, before Homebrew
+# has installed anything. Plain bash builtins only - no gum, no dialog, no
+# whiptail. bash 3.2 compatible (macOS ships 3.2 and this runs before brew
+# provides a newer one).
+#
 # The flag list is read from post-installation/defaults/main.yaml, so adding a
 # flag there is the only edit needed - this script picks it up automatically.
 
@@ -16,9 +21,6 @@ case "$(uname -s)" in
   *) PLAYBOOK="playbook.yaml" ;;
 esac
 
-# mapfile is bash 4+; macOS ships bash 3.2 and this script runs before
-# Homebrew provides a newer one. `while read` works on both.
-#
 # Boolean flags, in file order. Skips `all` - it is the "everything" shortcut,
 # not a per-feature choice.
 FLAGS=()
@@ -31,49 +33,100 @@ done < <(awk '/^[a-z_]+: (true|false)$/ {
 
 [ ${#FLAGS[@]} -gt 0 ] || { echo "No flags found in $DEFAULTS." >&2; exit 1; }
 
-# Default-on flags get pre-selected so the picker reflects current behaviour.
-PRESELECTED=()
-while IFS= read -r flag; do
-  PRESELECTED+=("$flag")
-done < <(awk '/^[a-z_]+: true$/ {split($0, f, ":"); if (f[1] != "all") print f[1]}' "$DEFAULTS")
-
-if ! command -v gum >/dev/null 2>&1; then
-  echo "gum is not installed. Either install it (brew install gum) or run:"
-  echo "  ansible-playbook ./$PLAYBOOK -K -e all=true"
-  exit 1
-fi
-
-gum style --border rounded --padding "0 1" \
-  "Griffin" "Pick what to install. Space selects, Enter confirms."
-
-selected_csv=$(IFS=,; echo "${PRESELECTED[*]-}")
-CHOSEN=()
-while IFS= read -r choice; do
-  CHOSEN+=("$choice")
-done < <(gum choose --no-limit --height 20 \
-           --selected "$selected_csv" \
-           --header "Feature flags (Ctrl-C to abort):" \
-           "${FLAGS[@]}")
-
-# gum exits 0 with no output if the user selects nothing.
-if [ ${#CHOSEN[@]} -eq 0 ]; then
-  echo "Nothing selected - installing core CLI tools and shell environment only."
-fi
-
-# Every flag is passed explicitly, on or off. Passing only the chosen ones
-# would let a default-true flag (kde, remove_snap) survive being deselected.
-ARGS=()
+# Current state, parallel array to FLAGS. Defaults come from the YAML, so
+# accepting everything reproduces a standard install.
+STATE=()
 for flag in "${FLAGS[@]}"; do
-  value=false
-  for chosen in ${CHOSEN[@]+"${CHOSEN[@]}"}; do
-    [ "$chosen" = "$flag" ] && value=true && break
+  if grep -q "^$flag: true$" "$DEFAULTS"; then
+    STATE+=(true)
+  else
+    STATE+=(false)
+  fi
+done
+
+# The comment lines above a flag document it. Show the first one as help text.
+describe() {
+  awk -v want="$1" '
+    /^#/ { comment = comment ? comment " " substr($0, 3) : substr($0, 3); next }
+    /^[a-z_]+:/ {
+      split($0, f, ":")
+      if (f[1] == want && comment) { print substr(comment, 1, 70); exit }
+      comment = ""
+      next
+    }
+    { comment = "" }
+  ' "$DEFAULTS"
+}
+
+toggle() {
+  local idx=$1
+  if [ "${STATE[idx]}" = true ]; then STATE[idx]=false; else STATE[idx]=true; fi
+}
+
+print_menu() {
+  echo
+  echo "  Griffin - select what to install"
+  echo "  ────────────────────────────────────────────────────────"
+  local i=0
+  for flag in "${FLAGS[@]}"; do
+    local mark=" "
+    [ "${STATE[$i]}" = true ] && mark="x"
+    printf "  %2d) [%s] %s\n" "$((i + 1))" "$mark" "$flag"
+    local help
+    help=$(describe "$flag")
+    [ -n "$help" ] && printf "         %s\n" "$help"
+    i=$((i + 1))
   done
-  ARGS+=(-e "$flag=$value")
+  echo "  ────────────────────────────────────────────────────────"
+  echo "  number = toggle   a = all on   n = none   q = quit"
+  echo
+}
+
+# Non-interactive (piped, CI): skip the menu and use the YAML defaults.
+if [ ! -t 0 ]; then
+  echo "Not a terminal - using defaults from $DEFAULTS."
+else
+  while true; do
+    print_menu
+    printf "  Toggle, or press Enter to continue: "
+    read -r reply || break
+    case "$reply" in
+      "") break ;;
+      q|Q) echo "Aborted."; exit 0 ;;
+      a|A) for i in "${!STATE[@]}"; do STATE[i]=true; done ;;
+      n|N) for i in "${!STATE[@]}"; do STATE[i]=false; done ;;
+      *[!0-9\ ]*) echo "  ! Enter a number, a, n, or q." ;;
+      *)
+        # Accept several numbers at once: "1 4 7"
+        for num in $reply; do
+          if [ "$num" -ge 1 ] 2>/dev/null && [ "$num" -le ${#FLAGS[@]} ]; then
+            toggle $((num - 1))
+          else
+            echo "  ! No option $num."
+          fi
+        done
+        ;;
+    esac
+  done
+fi
+
+# Every flag is passed explicitly, on or off. Passing only the enabled ones
+# would let a default-true flag (kde, remove_snap) survive being switched off.
+ARGS=()
+for i in "${!FLAGS[@]}"; do
+  ARGS+=(-e "${FLAGS[$i]}=${STATE[$i]}")
 done
 
 echo
-echo "ansible-playbook ./$PLAYBOOK -K ${ARGS[*]}"
+echo "  ansible-playbook ./$PLAYBOOK -K ${ARGS[*]}"
 echo
-gum confirm "Run it?" || exit 0
+
+if [ -t 0 ]; then
+  printf "  Run it? [Y/n] "
+  read -r confirm || true
+  case "$confirm" in
+    [nN]*) echo "Aborted."; exit 0 ;;
+  esac
+fi
 
 exec ansible-playbook "./$PLAYBOOK" -K "${ARGS[@]}"

--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -10,6 +10,9 @@ gestures: false
 fonts: false
 vpn: false
 mobile: false
+# Off, and excluded from `all`: not everyone wants a messenger installed.
+# Opt in with `-e viber=true` or `--tags viber`.
+viber: false
 # Wipe ~/.vim/plugged before installing plugins. Off: a re-run must not destroy
 # a working plugin set. Turn on for a clean reinstall.
 nvim_reset: false
@@ -223,6 +226,20 @@ tool_sets:
 
   # Opt-in only: installed with `-e all=true`. Not used day-to-day.
   utility_apps_macos_optional: []
+
+  # Opt-in only: installed with `-e all=true`. Not used day-to-day, and each
+  # one is heavy, account-bound, or personal taste.
+  # Mirrors the macOS *_optional lists.
+  gui_apps_debian_optional:
+    - name: RescueTime
+      package: rescuetime
+      url: https://www.rescuetime.com/installers/rescuetime_current_amd64.deb
+    - name: Zoom
+      package: zoom
+      url: https://zoom.us/client/latest/zoom_amd64.deb
+    - name: UnifiedRemote
+      package: unifiedremote
+      url: https://www.unifiedremote.com/download/linux-x64-deb
 
   # Nerd Fonts (cross-platform)
   nerd_fonts:

--- a/post-installation/tasks/debian/general_use_software_gui.yaml
+++ b/post-installation/tasks/debian/general_use_software_gui.yaml
@@ -1,10 +1,13 @@
 ---
-- name: Download and install RescueTime
+- name: Install optional GUI applications
   ansible.builtin.include_tasks: shared/utils/install_remote_deb.yaml
   vars:
-    remote_software_name: RescueTime
-    remote_package_name: rescuetime
-    remote_software_url: https://www.rescuetime.com/installers/rescuetime_current_amd64.deb
+    remote_software_name: "{{ item.name }}"
+    remote_package_name: "{{ item.package }}"
+    remote_software_url: "{{ item.url }}"
+  loop: "{{ tool_sets.gui_apps_debian_optional if all | bool else [] }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Fix Google Chrome duplicate repository entry
   ansible.builtin.include_tasks: shared/utils/clean_apt_conflicts.yaml
@@ -31,21 +34,16 @@
         state: present
         update_cache: true
 
-- name: Download and install Zoom
-  ansible.builtin.include_tasks: shared/utils/install_remote_deb.yaml
-  vars:
-    remote_software_name: Zoom
-    remote_package_name: zoom
-    remote_software_url: https://zoom.us/client/latest/zoom_amd64.deb
-
 - name: Download and install Viber
   ansible.builtin.include_tasks: shared/utils/install_remote_deb.yaml
   vars:
     remote_software_name: Viber
     remote_package_name: viber
     remote_software_url: https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
+  when: viber | bool
 
 - name: Download and install Tixati
+  when: all | bool
   block:
     - name: Download Tixati page
       ansible.builtin.get_url:
@@ -69,13 +67,6 @@
         remote_package_name: tixati
         remote_software_url: "{{ tixati_url_result.stdout }}"
 
-- name: Download and install UnifiedRemote
-  ansible.builtin.include_tasks: shared/utils/install_remote_deb.yaml
-  vars:
-    remote_software_name: UnifiedRemote
-    remote_package_name: unifiedremote
-    remote_software_url: https://www.unifiedremote.com/download/linux-x64-deb
-
 - name: Install apt apps - Variety, Flameshot, Bleachbit
   ansible.builtin.apt:
     name:
@@ -86,13 +77,6 @@
       - vlc
       - redshift
       - redshift-gtk
-
-- name: Download and install mailspring
-  ansible.builtin.include_tasks: shared/utils/install_github_asset.yaml
-  vars:
-    github_repo: Foundry376/mailspring
-    github_asset: mailspring
-    type: deb
 
 - name: Install ONLYOFFICE Desktop Editors
   block:
@@ -115,6 +99,7 @@
         update_cache: true
 
 - name: Install ModernCSV
+  when: all | bool
   block:
     - name: Download ModernCSV
       ansible.builtin.shell:

--- a/post-installation/tasks/debian/gui_applications.yaml
+++ b/post-installation/tasks/debian/gui_applications.yaml
@@ -11,5 +11,5 @@
   ansible.builtin.include_tasks:
     file: debian/general_use_software_gui.yaml
     apply:
-      tags: [gui]
-  when: (gui | bool) or (all | bool)
+      tags: [gui, viber]
+  when: (gui | bool) or (all | bool) or (viber | bool)

--- a/post-installation/tasks/main.yaml
+++ b/post-installation/tasks/main.yaml
@@ -23,6 +23,7 @@
     vpn: "{{ true if 'vpn' in ansible_run_tags else vpn }}"
     fonts: "{{ true if 'fonts' in ansible_run_tags else fonts }}"
     mobile: "{{ true if 'mobile' in ansible_run_tags else mobile }}"
+    viber: "{{ true if 'viber' in ansible_run_tags else viber }}"
     prune_caches: "{{ true if 'prune' in ansible_run_tags else prune_caches }}"
   when: ansible_run_tags | difference(['all', 'always']) | length > 0
   tags: [always]
@@ -75,7 +76,7 @@
     file: "{{ ansible_facts['os_family'] | lower }}/gui_applications.yaml"
     apply:
       tags: [gui]
-  when: (gui | bool) or (dev_tools_gui | bool) or (all | bool)
+  when: (gui | bool) or (dev_tools_gui | bool) or (all | bool) or (viber | bool)
   tags: [always]
 
 - name: Apply KDE Customizations


### PR DESCRIPTION
## What

Three related changes to how optional software gets installed.

### Viber is opt-in only
`viber: false` in defaults, gated with `when: viber | bool`, and deliberately **excluded from `all`**. WhatsApp covers day-to-day messaging, so Viber shouldn't arrive uninvited. Only `-e viber=true` (or `--tags viber`) installs it.

### Heavy GUI apps moved behind `all`
Debian now mirrors the macOS `*_optional` pattern:

- New `gui_apps_debian_optional` list (RescueTime, Zoom, UnifiedRemote) — plain deb-URL installs, driven by one loop instead of three near-identical task blocks.
- Tixati, ModernCSV keep their bespoke installers (scraped URL / tarball) but are gated `when: all | bool`.
- Mailspring dropped entirely — too buggy lately.

Plain `gui=true` now installs only the uncontroversial set: Chrome, VLC, ONLYOFFICE, Flameshot, Variety, redshift, bleachbit, input-remapper.

### `./install.sh` — interactive flag picker, no dependencies

Reads the boolean flags straight out of `defaults/main.yaml`, so adding a flag stays a single edit and the picker follows automatically. Flag descriptions come from the comments already in that file.

```
  Griffin - select what to install
  ────────────────────────────────────────────────────────
   1) [ ] dev_tools_gui
   2) [ ] gui
  11) [ ] viber
         Off, and excluded from `all`: not everyone wants a messenger installed
  14) [x] kde
  ────────────────────────────────────────────────────────
  number = toggle   a = all on   n = none   q = quit
```

The first version of this used [`gum`](https://github.com/charmbracelet/gum) — but gum is installed *by this playbook*, so the picker couldn't run on the fresh system it exists for. Reimplemented with bash builtins: no gum, no dialog, no whiptail, and bash 3.2 compatible since macOS ships 3.2 and this runs before Homebrew provides anything newer.

One other decision worth noting: it **passes every flag explicitly** (`-e gui=true -e kde=false`, …), not just the enabled ones. Passing only the enabled set would let a default-true flag (`kde`, `remove_snap`) survive being switched off. Defaults are seeded from the YAML, so pressing Enter reproduces today's standard install.

Non-interactive callers (pipes, CI) skip the menu and use the YAML defaults.

## Verification

- `ansible-playbook ./playbook.yaml --syntax-check` passes
- `ansible-lint` clean on all touched files
- `shellcheck install.sh` clean, `bash -n` clean
- Flag gating verified against real `defaults/main.yaml`: default skips Viber; `all=true` installs the optional list but still skips Viber; `viber=true` installs it
- Picker verified end to end over a pty with a stubbed `ansible-playbook`: multi-toggle (`2 11`), `a` (15 flags on), `n` (0 on), `q` and declining both abort without invoking ansible, non-numeric and out-of-range input both rejected, non-tty path falls back to YAML defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019em9i2x1NSKBYr7u8XGWNf