### PR TITLE
chore: drop python-dependent brew tools

### DIFF
--- a/post-installation/defaults/main.yaml
+++ b/post-installation/defaults/main.yaml
@@ -46,7 +46,6 @@ tool_sets:
     - curl
     - git
     - gpg
-    - python3-pip
     - procps
     - file
     - unzip
@@ -55,8 +54,6 @@ tool_sets:
   # All CLI tools via Homebrew (both Debian and macOS)
   modern_cli_homebrew:
     - agg
-    - ansible
-    - ansible-lint
     - asciinema
     - atuin
     - bandwhich
@@ -68,15 +65,12 @@ tool_sets:
     - eza
     - fd
     - fzf
-    - gemini-cli
     - gh
     - git-delta
-    - git-filter-repo
     - gping
     - gum
     - htmlq
     - htop
-    - httpie
     - hyperfine
     - jq
     - lazydocker
@@ -87,7 +81,6 @@ tool_sets:
     - nano
     - ncdu
     - pandoc
-    - pipx
     - qrencode
     - ripgrep
     - sd
@@ -125,7 +118,6 @@ tool_sets:
     - grex
     - gron
     - helix
-    - httpstat
     - jless
     - lsd
     - lynx
@@ -134,16 +126,13 @@ tool_sets:
     - miller
     - mkcert
     - navi
-    - nmap
     - oha
     - peco
     - procs
     - rbenv
     - tealdeer
-    - thefuck
     - tokei
     - viddy
-    - visidata
     - webp
     - xh
     - zellij


### PR DESCRIPTION
Removes brew formulae that pulled in `python@3.14` without earning their keep. After this change, Homebrew no longer installs Python at all.

## Removed

**Always-installed (`modern_cli_homebrew`)**
- `ansible`, `ansible-lint` — both already provided by apt (`ansible-core 2.20.1`, `ansible-lint 26.1.1`)
- `gemini-cli` — the only formula pulling in brew's `node`; node comes from mise
- `git-filter-repo`, `httpie`, `pipx` — unused

**Opt-in (`modern_cli_homebrew_optional`, `all=true`)**
- `httpstat`, `thefuck`, `visidata`, `nmap`

**Prerequisites**
- `python3-pip` — not needed for the Homebrew bootstrap, and nothing installs through it

## Notes

`ansible-lint` stays wired into `.pre-commit-config.yaml` and `.github/workflows/reviewdog.yaml`. Neither used the brew copy — pre-commit builds its own isolated env and CI installs via the reviewdog action — so linting is unaffected.

Verified locally: `ansible-playbook --syntax-check ./playbook.yaml` passes, `git`/`ansible`/`ansible-lint` resolve to apt, `node` resolves to mise. Removing these locally freed ~640MB once dependency cascades were swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFdZWpRDtmUDy4WRSyijPq